### PR TITLE
Update Repository Reference to “LCR”

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This module's materials are adapted from the Deep Learning module taught at [Mas
 | 6     | TBD  | Recurrent Neural Networks and NLP                         | [Slides](./01_materials/slides/06_natural_language_processing_with_deep_learning.pdf) | [Lab 6 Workbook](./01_materials/labs/lab_6.ipynb) |                                                                                                         |
  
 ### Requirements
-* Participants are expected to have completed Shell, Git, Python, Applying Statistical Concepts, Production, and Algorithms & Data Structures learning modules.
+* Participants are expected to have completed Shell, Git, Python, Linear Regression, Classification, and Resampling, Production, and Algorithms & Data Structures learning modules.
 * Participants are encouraged to ask questions, and collaborate with others to enhance their learning experience.
 * Participants must have a computer and an internet connection to participate in online activities.
 * Participants must not use generative AI such as ChatGPT to generate code in order to complete assignments. It should be used as a supportive tool to seek out answers to questions you may have.


### PR DESCRIPTION
### Summary

This PR updates references to the module repository, reflecting the recent renaming from “Applying Statistical Concepts” to “Linear Regression, Classification, and Resampling” (LCR). To prevent overly long URLs, the repo name has been shortened to “LCR.” These changes align all dependent repos with the new module name and ensure continued functionality without breaking links or references.

### Changes

* Updated references from applying_statistical_concepts to LCR across the codebase.
* Revised any hardcoded paths, URLs, and documentation links to reflect the new repository name.
* Updated any import statements, dependency files, or other instances referencing the old module name, if applicable.